### PR TITLE
update_page should not require parent_id

### DIFF
--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -67,7 +67,7 @@ class Confluence(AtlassianRestAPI):
             version = self.history(page_id)['lastUpdated']['number'] + 1
 
             data = {
-                id': page_id,
+                'id': page_id,
                 'type': type,
                 'title': title,
                 'body': {'storage': {

--- a/atlassian/confluence.py
+++ b/atlassian/confluence.py
@@ -59,21 +59,26 @@ class Confluence(AtlassianRestAPI):
             log.info('Content of {page_id} differs'.format(page_id=page_id))
             return False
 
-    def update_page(self, parent_id, page_id, title, body, type='page'):
+    def update_page(self, parent_id=None, page_id, title, body, type='page'):
         log.info('Updating {type} "{title}"'.format(title=title, type=type))
         if self.is_page_content_is_already_updated(page_id, body):
             return self.get_page_by_id(page_id)
         else:
             version = self.history(page_id)['lastUpdated']['number'] + 1
-            return self.put('/rest/api/content/{0}'.format(page_id), data={
-                'id': page_id,
+
+            data = {
+                id': page_id,
                 'type': type,
-                'ancestors': [{'type': 'page', 'id': parent_id}],
                 'title': title,
                 'body': {'storage': {
                     'value': body,
                     'representation': 'storage'}},
-                'version': {'number': version}})
+                'version': {'number': version}}
+            }
+
+            if parent_id is not None:
+                data['ancestors']: [{'type': 'page', 'id': parent_id}]
+            return self.put('/rest/api/content/{0}'.format(page_id), data=data)
 
     def update_or_create(self, parent_id, title, body):
         space = self.get_page_space(parent_id)


### PR DESCRIPTION
The `update_page` method in confluence should not require a `parent_id`.  It looks like the `examples/confluence-update-page.py` also isn't expecting a required parent_id.

I've modified the method to work with a parent_id for old code, and not require it for new code (why I didn't move the named param with default value to the end).

Thanks!
Nick